### PR TITLE
feat(chat): add Field_index props

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -9,14 +9,23 @@ router.use(checkAuth);
 
 router.post("/", async (req, res, next) => {
   const data = req.body;
+  console.log(data);
+  const id = data.id;
+  const message = data.message;
+  const field = data.field;
   const sql = "insert into user_chat set ?";
   const chat = {
-    user_id: "",
-    field_index: "",
-    chat_message: "",
-    isUser: "",
+    user_id: id,
+    field_index: field,
+    chat_message: message,
+    isUser: true,
     chatDate: "",
   };
+  res.status(201).json({
+    id: chat.user_id,
+    field: chat.field_index,
+    msg: chat.chat_message,
+  });
 });
 
 module.exports = router;

--- a/frontend/src/component/Chat.js
+++ b/frontend/src/component/Chat.js
@@ -1,8 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import classes from "./Chat.module.css";
-import InputChat from "./ChatForm";
-const Chat = () => {
+import ChatForm from "./ChatForm";
+const Chat = (props) => {
   const [chatList, setChatList] = useState([]);
+
+  useEffect(() => {
+    console.log(props.field);
+  }, [props.field]);
+
   const AddChatToList = (items) => {
     setChatList((prev) => {
       return [...prev, items];
@@ -22,7 +27,7 @@ const Chat = () => {
           })}
         </ul>
       </div>
-      <InputChat onAdd={AddChatToList}></InputChat>
+      <ChatForm field={props.field} onAdd={AddChatToList}></ChatForm>
     </div>
   );
 };

--- a/frontend/src/component/ChatForm.js
+++ b/frontend/src/component/ChatForm.js
@@ -13,9 +13,11 @@ const ChatForm = (props) => {
     props.onAdd(chatText);
     const id = localStorage.getItem("id");
     const token = localStorage.getItem("token");
+    const field = props.field;
     const chatInfo = {
       message: chatText,
       id: id,
+      field: field,
     };
     const response = await fetch("http://localhost:8080/chat", {
       method: "POST",
@@ -23,12 +25,10 @@ const ChatForm = (props) => {
         "Content-Type": "application/json",
         Authorization: "Bearer " + token,
       },
-      body: JSON.stringify({
-        body: chatInfo,
-      }),
+      body: JSON.stringify(chatInfo),
     });
-    const responseData = await response.json();
-    console.log(responseData);
+    const resData = await response.json();
+    console.log(resData);
     setChatText("");
   };
 

--- a/frontend/src/component/Contents.js
+++ b/frontend/src/component/Contents.js
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import classes from "./Contents.module.css";
-import ChatUI from "./Chat";
-import BottomUI from "./Bottom";
-import SideUI from "./Side";
+import Chat from "./Chat";
+import Bottom from "./Bottom";
+import Side from "./Side";
 
 const Contents = () => {
   const [curField, setCurField] = useState(0);
@@ -14,11 +14,11 @@ const Contents = () => {
   return (
     <div className={classes.wrapper}>
       <div className={classes.primary}>
-        <ChatUI field={curField} />
-        <BottomUI />
+        <Chat field={curField} />
+        <Bottom />
       </div>
       <div className={classes.secondary}>
-        <SideUI onChangeField={curFieldHandler} />
+        <Side onChangeField={curFieldHandler} />
       </div>
     </div>
   );

--- a/frontend/src/component/Side.js
+++ b/frontend/src/component/Side.js
@@ -1,7 +1,23 @@
 import classes from "./Side.module.css";
 
-const Side = () => {
-  return <div className={classes.wrapper}></div>;
+const Side = (props) => {
+  const changeFieldHandler1 = () => {
+    props.onChangeField(1);
+  };
+  const changeFieldHandler2 = () => {
+    props.onChangeField(2);
+  };
+  const changeFieldHandler3 = () => {
+    props.onChangeField(3);
+  };
+
+  return (
+    <div className={classes.wrapper}>
+      <button onClick={changeFieldHandler1}>button1</button>
+      <button onClick={changeFieldHandler2}>button2</button>
+      <button onClick={changeFieldHandler3}>button3</button>
+    </div>
+  );
 };
 
 export default Side;


### PR DESCRIPTION
1. Contents -> Chat -> ChatForm 으로 현재 채팅 필드 인덱스 props를 통해서 넘겨줌.
컨텍스트나 다른 기능 쓰지 않고 props 로 한 이유는 , props의 이동이 길어지지 않을 것이라고 생각하기 때문임. 
이후 수정될 수 있음

2. 백엔드 수정 (chat.js) : frontend에서 field index, id, message 넘겨 받는 것 확인