### PR TITLE
fix(pages:frontend) : 채팅 필드 props가 아닌 url를 이용해서 db 불러오기

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,7 +5,8 @@ import HomePage from "./pages/HomePage";
 import AuthPage from "./pages/AuthPage";
 import MainPage from "./pages/MainPage";
 import { action as authAction } from "./pages/AuthPage";
-
+import { loader as chatLoader } from "./pages/MainPage";
+import ChatPage from "./pages/ChatPage";
 const router = createBrowserRouter([
   {
     path: "/",
@@ -15,7 +16,17 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: "auth", element: <AuthPage></AuthPage>, action: authAction },
-      { path: "main", element: <MainPage></MainPage> },
+      {
+        path: "main",
+        element: <MainPage></MainPage>,
+        loader: chatLoader,
+      },
+      {
+        path: "/main/:id",
+        id: "chat-field",
+        element: <MainPage></MainPage>,
+        loader: chatLoader,
+      },
     ],
   },
 ]);

--- a/frontend/src/component/Contents.js
+++ b/frontend/src/component/Contents.js
@@ -5,20 +5,14 @@ import Bottom from "./Bottom";
 import Side from "./Side";
 
 const Contents = () => {
-  const [curField, setCurField] = useState(0);
-
-  const curFieldHandler = (cur) => {
-    setCurField(cur);
-  };
-
   return (
     <div className={classes.wrapper}>
       <div className={classes.primary}>
-        <Chat field={curField} />
+        <Chat />
         <Bottom />
       </div>
       <div className={classes.secondary}>
-        <Side onChangeField={curFieldHandler} />
+        <Side />
       </div>
     </div>
   );

--- a/frontend/src/component/Side.js
+++ b/frontend/src/component/Side.js
@@ -1,21 +1,21 @@
+import { Link } from "react-router-dom";
 import classes from "./Side.module.css";
 
 const Side = (props) => {
-  const changeFieldHandler1 = () => {
-    props.onChangeField(1);
-  };
-  const changeFieldHandler2 = () => {
-    props.onChangeField(2);
-  };
-  const changeFieldHandler3 = () => {
-    props.onChangeField(3);
-  };
-
   return (
     <div className={classes.wrapper}>
-      <button onClick={changeFieldHandler1}>button1</button>
-      <button onClick={changeFieldHandler2}>button2</button>
-      <button onClick={changeFieldHandler3}>button3</button>
+      <button>button1</button>
+      <button>button2</button>
+      <button>button3</button>
+      <Link to="/main/one">
+        <button>Link1</button>
+      </Link>
+      <Link to="/main/two">
+        <button>Link2</button>
+      </Link>
+      <Link to="/main/three">
+        <button>Link3</button>
+      </Link>
     </div>
   );
 };

--- a/frontend/src/component/TempTest.js
+++ b/frontend/src/component/TempTest.js
@@ -1,0 +1,10 @@
+import React from "react";
+const TempTest = () => {
+  return (
+    <>
+      <div>111111111111</div>
+    </>
+  );
+};
+
+export default TempTest;

--- a/frontend/src/pages/ChatPage.js
+++ b/frontend/src/pages/ChatPage.js
@@ -1,0 +1,7 @@
+import { Outlet, defer } from "react-router-dom";
+
+const ChatPage = () => {
+  return <Outlet></Outlet>;
+};
+
+export default ChatPage;

--- a/frontend/src/pages/MainPage.js
+++ b/frontend/src/pages/MainPage.js
@@ -1,5 +1,14 @@
+import { Suspense } from "react";
+import { Await } from "react-router-dom";
+import { Outlet, defer } from "react-router-dom";
 import Contents from "../component/Contents";
 const MainPage = () => {
   return <Contents></Contents>;
 };
 export default MainPage;
+
+export async function loader({ request, params }) {
+  const id = params.id;
+  console.log(id);
+  return defer({});
+}


### PR DESCRIPTION
1. 원래 props 이용해서 현재 패팅 필드 정보 전달했는데, 이러면 새로고침 시 초기화가 되어버려서 react-router-dom 기능을 활용해 특정 url 진입 시 loader 함수로 db 내용 받아오는 것으로 수정함. 

2. Chat (frontend) 쪽은 지금 정상 작동 하지 않을 것임. 수정할 것임