### PR TITLE
fix(memo, userInfo): memo 및 userInfo 버그 수정

### DIFF
--- a/frontend/src/component/Memo.js
+++ b/frontend/src/component/Memo.js
@@ -45,7 +45,7 @@ const Memo = (props) => {
           memoId={memoId}
           memoText={
             memoId !== undefined
-              ? props.memoList.find((obj) => obj.id === memoId)?.memoText
+              ? props.memoList.find((obj) => obj.memoId === memoId)?.memoText
               : ""
           }
           onAdd={AddHandler}

--- a/frontend/src/component/MemoForm.js
+++ b/frontend/src/component/MemoForm.js
@@ -15,6 +15,7 @@ const MemoForm = (props) => {
   };
 
   const SubmitHandler = async (event) => {
+    console.log(props.memoText);
     event.preventDefault();
     const token = localStorage.getItem("token");
     if (props.memoId === undefined) {
@@ -70,7 +71,7 @@ const MemoForm = (props) => {
         <input
           type="text"
           name="memo"
-          value={memoText}
+          value={memoText || ""}
           onChange={memoTextHandler}
         ></input>
       </form>

--- a/frontend/src/component/UserInfoForm.js
+++ b/frontend/src/component/UserInfoForm.js
@@ -63,7 +63,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.nickName}
+            defaultValue={props.userInfo.nickName}
           ></input>
         </form>
       )}
@@ -78,7 +78,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.firstName}
+            defaultValue={props.userInfo.firstName}
           ></input>
         </form>
       )}
@@ -93,7 +93,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.lastName}
+            defaultValue={props.userInfo.lastName}
           ></input>
         </form>
       )}
@@ -108,7 +108,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.dept}
+            defaultValue={props.userInfo.dept}
           ></input>
         </form>
       )}
@@ -123,7 +123,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.phoneNumber}
+            defaultValue={props.userInfo.phoneNumber}
           ></input>
         </form>
       )}
@@ -138,7 +138,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.grade}
+            defaultValue={props.userInfo.grade}
           ></input>
         </form>
       )}
@@ -153,7 +153,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.earned_credit}
+            defaultValue={props.userInfo.earned_credit}
           ></input>
         </form>
       )}
@@ -168,7 +168,7 @@ const UserInfoForm = (props) => {
             className={classes.Input}
             type="text"
             name="Input"
-            value={props.userInfo.goal_credit}
+            defaultValue={props.userInfo.goal_credit}
           ></input>
         </form>
       )}


### PR DESCRIPTION
1. 원래 memo 를 클릭해서 편집하는건데, 이 때 기존의 memoText는 남아야하도록 구현을 했으나, 기존의 텍스트가 input에 뜨지 않는 오류 발생
-> 해결

2. userInfo 에 input 태그 warning
Warning: You provided a value prop to a form field without an onChange handler. This will render a read-only field. If the field should be mutable use defaultValue. Otherwise, set either onChange or readOnly.
value -> defaultValue 를 통해서 수정 